### PR TITLE
Fix glibc version mismatch in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log*
+yarn-error.log*
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+README.md
+data
+*.sqlite
+*.db
+public/background.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
 # syntax=docker/dockerfile:1
-FROM node:20-bullseye-slim
+
+# Build stage with full toolchain to compile native modules (e.g., better-sqlite3)
+FROM node:20-bullseye AS build
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install --production
-COPY . .
+# Install build tools for native modules (only in build stage)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm ci --omit=dev
+
+# Runtime stage: slim image with only production deps and app code
+FROM node:20-bullseye-slim
+WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
+COPY --from=build /app/node_modules ./node_modules
+COPY . .
 EXPOSE 3000
 CMD ["npm","start"]


### PR DESCRIPTION
Implement multi-stage Docker build and `.dockerignore` to resolve GLIBC version mismatch for native modules.

The previous Docker setup caused a `GLIBC_2.38` not found error for `better-sqlite3` because native modules were either copied from the host or compiled in an incompatible environment. This change ensures they are built correctly within the Docker image.

---
<a href="https://cursor.com/background-agent?bcId=bc-185f16c1-2746-4a15-a382-8bb4138bf031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-185f16c1-2746-4a15-a382-8bb4138bf031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

