### PR TITLE
Remove https references from application

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,12 +4,18 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>deZents kleine Bambu-Gutschein Verwaltung</title>
-  <link rel="stylesheet" href="/styles.css" />
+  <script>
+    // Force HTTP to avoid SSL errors when server doesn't support HTTPS
+    if (location.protocol === 'https:') {
+      location.replace('http://' + location.host + location.pathname + location.search + location.hash);
+    }
+  </script>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <div id="app">Lade
 
 </div>
-  <script src="/main.js" type="module"></script>
+  <script src="main.js" type="module"></script>
 </body>
 </html>

--- a/public/test.html
+++ b/public/test.html
@@ -4,7 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Testseite – Bambu-Gutschein</title>
-  <link rel="stylesheet" href="/styles.css" />
+  <script>
+    if (location.protocol === 'https:') {
+      location.replace('http://' + location.host + location.pathname + location.search + location.hash);
+    }
+  </script>
+  <link rel="stylesheet" href="styles.css" />
   <style>
     .ok { color: #10b981; }
     .bad { color: #ef4444; }


### PR DESCRIPTION
Add HTTP-only redirect and use relative asset paths to resolve SSL protocol errors.

The application was encountering `net::ERR_SSL_PROTOCOL_ERROR` when accessed via HTTPS because the server was not configured to handle SSL. This change ensures that all requests are made over HTTP and assets are loaded correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ad9cbd6-25df-4be4-a739-9cc86adc9178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ad9cbd6-25df-4be4-a739-9cc86adc9178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

